### PR TITLE
Enable Github actions to build and release AMD64 and ARM64 images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Prepare
+        id: prepare
+        run: |
+            TAG=${GITHUB_REF##*/}
+            echo ::set-output name=tag_name::${TAG}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login do docker.io
+        run: docker login -u navicore -p ${{ secrets.DOCKER_TOKEN }}
+      - name: build and publish image
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            navicore/team-notification-resource:${{ steps.prepare.outputs.tag_name }}
+            navicore/team-notification-resource:latest


### PR DESCRIPTION
Added .github/workflows/ci.yml file to build and push the image for both amd64 and arm64 platforms.

Signed-off-by: odidev <odidev@puresoftware.com>