### PR TITLE
Adds a `text_file parameter` for issue #3.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login do docker.io
+        if: startsWith(github.ref, 'refs/tags/')
         run: docker login -u navicore -p ${{ secrets.DOCKER_TOKEN }}
       - name: build and publish image
+        if: startsWith(github.ref, 'refs/tags/')
         id: docker_build
         uses: docker/build-push-action@v2
         with:

--- a/README.md
+++ b/README.md
@@ -105,8 +105,9 @@ example of an alert in a pull-request job
         actionName: {{mypipeline}} Pipeline
         actionTarget: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
 ```
-
-* `text`: *Required.* Text of the message to send - markdown supported
+* One of the following:
+  * `text`: *Required.* Text of the message to send - markdown supported (higher precedence over `text_file`)
+  * `text_file`: *Required.* A location of text file of the message to send, usually an output from a previous task - markdown supported
 * `title`: *Optional.*
 * `color`: *Optional.* Sidebar color (doesn't appear to be implemented yet in the Teams UI)
 * `actionName`: *Optional.* Text on the button/link (shows up as a link though the Teams docs show a button)

--- a/out
+++ b/out
@@ -29,9 +29,26 @@ actionTarget=$(evaluate "$(jq -r '.params.actionTarget // "https://concourse.ci"
 
 title=$(evaluate "$(jq -r '.params.title // "Concourse CI"' < "${payload}")")
 
-text=$(evaluate "$(jq -r '.params.text // "NO MSG"' < "${payload}")")
+text=$(evaluate "$(jq -r '.params.text // ""' < "${payload}")")
+text_file=$(evaluate "$(jq -r '.params.text_file // ""' < "${payload}")")
 
-body="{\"TextFormat\": \"${format}\", \"text\": \"${text}\", \"title\": \"${title}\", \"themeColor\": \"${color}\", \"potentialAction\": [{\"@context\": \"https://schema.org\", \"@type\": \"ViewAction\", \"name\": \"${actionName}\", \"target\": [\"${actionTarget}\"]}]}"
+# - 'text' always overrides 'text_file'
+# - '_(NO MSG)_' being the default if neither are provded
+# - If text file is missing: _(NO MSG FILE)_
+# - If text file is blank: _(EMPTY MSG FILE)_"
+text_output="_(NO MSG)_"
+if [[ -n "${text_file}" ]]; then
+  if [[ ! -f "${text_file}" ]]; then
+    text_output="_(NO MSG FILE)_"
+  else
+    text_output="$(cat "${text_file}")" && \
+              [[ -z "${text_output}" ]] && \
+			  text_output="_(EMPTY MSG FILE)_"
+  fi
+fi
+[[ -n "${text}" ]] && text_output="${text}"
+
+body="{\"TextFormat\": \"${format}\", \"text\": \"${text_output}\", \"title\": \"${title}\", \"themeColor\": \"${color}\", \"potentialAction\": [{\"@context\": \"https://schema.org\", \"@type\": \"ViewAction\", \"name\": \"${actionName}\", \"target\": [\"${actionTarget}\"]}]}"
 
 webhook_url="$(jq -r '.source.url' < "${payload}")"
 redacted_webhook_url=$(echo "${webhook_url}" | sed -e 's#/\([^/\.]\{2\}\)[^/.]\{5,\}\([^/.]\{2\}\)#/\1…\2#g' | jq -R .)


### PR DESCRIPTION
- `text` always overrides `text_file` (backwards compatible)
- If neither are provded: _(NO MSG)_
- If text file is missing: _(NO MSG FILE)_
- If text file is blank: _(EMPTY MSG FILE)_