### PR TITLE
need to provide workdir to get text_file to work

### DIFF
--- a/out
+++ b/out
@@ -30,7 +30,7 @@ actionTarget=$(evaluate "$(jq -r '.params.actionTarget // "https://concourse.ci"
 title=$(evaluate "$(jq -r '.params.title // "Concourse CI"' < "${payload}")")
 
 text=$(evaluate "$(jq -r '.params.text // ""' < "${payload}")")
-text_file=$(evaluate "$(jq -r '.params.text_file // ""' < "${payload}")")
+text_file="$1/"$(evaluate "$(jq -r '.params.text_file // ""' < "${payload}")")
 
 # - 'text' always overrides 'text_file'
 # - '_(NO MSG)_' being the default if neither are provded


### PR DESCRIPTION
> The `out` script is passed a path to the directory containing the build's full set of sources as command line argument `$1`

https://concourse-ci.org/implementing-resource-types.html#resource-out

since `outputs` get persisted in the temp build directory, we need to prepend the `text_file` input with the path to the working directory

fixes #14