### PR TITLE
using ubuntu base image 21.04 because it is smaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:21.04
 
 ADD http://stedolan.github.io/jq/download/linux64/jq /usr/local/bin/jq
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ATC_EXTERNAL_URL
 
 ## STATUS
 
-* Alpha Quality
+* Actively used and supported (as of Oct '21)
 * Works - meets my specific needs
 
 


### PR DESCRIPTION
21.04 is smaller than old 16 - tests fine for me. 

open to suggestions for a smaller base like alpine but would need a PR to use apk.