### PR TITLE
https://github.com/navicore/teams-notification-resource/issues/17

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016 Ed Sweeney
+Copyright (c) 2016-2022 Ed Sweeney
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ resources:
       proxy_port: 1234                                            [optional]
       proxy_username: myusername                                  [optional]
       proxy_password: mysecret                                    [optional]
+      skip_cert_verification                                      [optional]
 
 ```
 * `url`: *Required.* The webhook URL as provided by Teams when you add a
@@ -73,6 +74,9 @@ form: `https://outlook.office365.com/webhook/XXX`
 * `proxy_port`: *Optional.* Basic auth for forwarding proxies
 * `proxy_username`: *Optional.* Basic auth for forwarding proxies
 * `proxy_password`: *Optional.* Basic auth for forwarding proxies
+* `skip_cert_verification`: *Optional.* cURL `-k` option for debugging when behind TLS rewrite proxies when the internal cert is self-signed or not properly distributed
+* `verbose`: *Optional.* cURL `-v` option for debugging 
+* `silent`: *Optional.* cURL `-s` option for no logging 
 
 next, define the non-built-in type:
 

--- a/out
+++ b/out
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-CURL_OPTION="-v"
+CURL_OPTION=""
 
 set -e
 exec 3>&1
@@ -56,6 +56,9 @@ proxy_url="$(jq -r '.source.proxy_url // empty' < "${payload}")"
 proxy_port="$(jq -r '.source.proxy_port // empty' < "${payload}")"
 proxy_username="$(jq -r '.source.proxy_username // empty' < "${payload}")"
 proxy_password="$(jq -r '.source.proxy_password // empty' < "${payload}")"
+skip_cert_verification="$(jq -r '.source.skip_cert_verification // empty' < "${payload}")"
+verbose="$(jq -r '.source.verbose // empty' < "${payload}")"
+silent="$(jq -r '.source.silent // empty' < "${payload}")"
 
 if [ -z ${proxy_url} ] || [ -z ${proxy_port} ]; then
   PROXY_OPTIONS=""
@@ -67,6 +70,24 @@ if [ -z ${proxy_url} ] || [ -z ${proxy_port} ] || [ -z ${proxy_username} ] || [ 
   PROXY_OPTIONS="${PROXY_OPTIONS}"
 else
   PROXY_OPTIONS="--proxy-user ${proxy_username}:${proxy_password} ${PROXY_OPTIONS}" 
+fi
+
+if [ -z ${skip_cert_verification} ]; then
+  CURL_OPTION="${CURL_OPTION}"
+else
+  CURL_OPTION="-k ${CURL_OPTION}" 
+fi
+
+if [ -z ${verbose} ]; then
+  CURL_OPTION="${CURL_OPTION}" 
+else
+  CURL_OPTION="-v ${CURL_OPTION}" 
+fi
+
+if [ -z ${silent} ]; then
+  CURL_OPTION="${CURL_OPTION}" 
+else
+  CURL_OPTION="-s ${CURL_OPTION}" 
 fi
 
 redacted_webhook_url=$(echo "${webhook_url}" | sed -e 's#/\([^/\.]\{2\}\)[^/.]\{5,\}\([^/.]\{2\}\)#/\1…\2#g' | jq -R .)


### PR DESCRIPTION
adding 3 more resource params:

1. `silent` - turns off all logging
2. `verbose` - same as previous logging
3. `skip_cert_verification` - turns of inspection of signing cert.  this option is a debug tool for those behind tls rewrite proxies like goskope.

new default behavior is modest logging - use the `-v` option otherwise