### PR TITLE
set content-type on webhook curl request

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
 FROM ubuntu:22.04
 
-ADD http://stedolan.github.io/jq/download/linux64/jq /usr/local/bin/jq
-
 COPY check /opt/resource/check
 COPY in    /opt/resource/in
 COPY out   /opt/resource/out
 
-RUN chmod +x /usr/local/bin/jq /opt/resource/out /opt/resource/in /opt/resource/check && \
+RUN chmod +x /opt/resource/out /opt/resource/in /opt/resource/check && \
     apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y curl
+    DEBIAN_FRONTEND=noninteractive apt-get install -y curl jq
 

--- a/out
+++ b/out
@@ -94,7 +94,7 @@ redacted_webhook_url=$(echo "${webhook_url}" | sed -e 's#/\([^/\.]\{2\}\)[^/.]\{
 
 url_path="$(echo ${webhook_url} | sed -e "s/https\{0,1\}:\/\/[^\/]*\(\/[^?&#]*\).*/\1/")"
 
-curl ${CURL_OPTION} ${PROXY_OPTIONS} -d "${body}" "${webhook_url}" 2>&1 | sed -e "s#${url_path}#***WEBHOOK URL REDACTED***#g"
+curl ${CURL_OPTION} ${PROXY_OPTIONS} -H 'Content-Type: application/json' -d "${body}" "${webhook_url}" 2>&1 | sed -e "s#${url_path}#***WEBHOOK URL REDACTED***#g"
 
 timestamp=$(date +%s)
 metadata="$(cat <<EOF


### PR DESCRIPTION
Fixes #36 

Note: I was unable to run `docker build` to test this change because of:

```
------
 > http://stedolan.github.io/jq/download/linux64/jq:
------
ERROR: failed to solve: failed to load cache key: invalid response status 404
```

but instead of doing:

```
ADD http://stedolan.github.io/jq/download/linux64/jq /usr/local/bin/jq
```

I think `jq` can just be installed with apt. Happy to include that change in the PR as well!