### PR TITLE
convert message to adaptive cards with colored headers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM ubuntu:22.04
 
-COPY check /opt/resource/check
-COPY in    /opt/resource/in
-COPY out   /opt/resource/out
-
-RUN chmod +x /opt/resource/out /opt/resource/in /opt/resource/check && \
-    apt-get update && \
+RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y curl jq
 
+COPY check   /opt/resource/check
+COPY in      /opt/resource/in
+COPY out     /opt/resource/out
+COPY card.jq /opt/resource/card.jq
+
+RUN chmod +x /opt/resource/out /opt/resource/in /opt/resource/check

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Example of an alert in a pull-request job:
       put: alert
       params:
         text: |
-          pull request tested: with no errors
+          pull request tested: success
         title: {{mypipeline}} Pull Request Tested
         actionName: {{mypipeline}} Pipeline
         actionTarget: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
@@ -119,9 +119,10 @@ Example of an alert in a pull-request job:
   * `text`: *Required.* Text of the message to send - markdown supported (higher precedence over `text_file`)
   * `text_file`: *Required.* A location of text file of the message to send, usually an output from a previous task - markdown supported
 * `title`: *Optional.*
-* `color`: *Optional.* 
 * `actionName`: *Optional.* Text on the button/link (shows up as a link though the Teams docs show a button)
 * `actionTarget`: *Optional.* URL to connect to the button/link
+* `style`: *Optional.* Adaptive Card header style. Can be one of 'good', 'attention', 'warning'. If not provided, `title` and `text` are scanned for keywords to determine the style. If no keywords are found, 'default' is used.
+* ~~`color`~~: *Deprecated* 
 
 # MORE EXAMPLES
 

--- a/card.jq
+++ b/card.jq
@@ -1,0 +1,44 @@
+{
+	"type": "message",
+	"attachments": [
+		{
+			"contentType": "application/vnd.microsoft.card.adaptive",
+			"contentUrl": null,
+			"content": {
+				"type": "AdaptiveCard",
+				"body": [
+					{
+						"type": "Container",
+						"items": [
+							{
+								"type": "TextBlock",
+								"text": $title,
+								"wrap": true,
+								"size": "Large",
+								"weight": "Bolder"
+							}
+						],
+						"style": $style
+					},
+					{
+						"type": "TextBlock",
+						"text": $text,
+						"wrap": true
+					}
+				],
+				"actions": [
+					{
+						"type": "Action.OpenUrl",
+						"title": $actionName,
+						"url": $actionTarget
+					}
+				],
+				"msteams": {
+					"width": "Full"
+				},
+				"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+				"version": "1.5"
+			}
+		}
+	]
+}

--- a/out
+++ b/out
@@ -21,7 +21,6 @@ payload=$(mktemp /tmp/resource-in.XXXXXX)
 cat > "${payload}" <&0
 
 format="markdown"
-color="$(jq -r '.params.color // "00EA43"' < "${payload}")"
 
 actionName=$(evaluate "$(jq -r '.params.actionName // "Open Concourse"' < "${payload}")")
 
@@ -48,7 +47,31 @@ if [[ -n "${text_file}" ]]; then
 fi
 [[ -n "${text}" ]] && text_output="${text}"
 
-body="{\"TextFormat\": \"${format}\", \"text\": \"${text_output}\", \"title\": \"${title}\", \"themeColor\": \"${color}\", \"potentialAction\": [{\"@context\": \"https://schema.org\", \"@type\": \"ViewAction\", \"name\": \"${actionName}\", \"target\": [\"${actionTarget}\"]}]}"
+# style should be one of 'good', 'attention', 'warning', 'default'
+# good (green) if the build succeeded
+# attention (red) if the build failed
+# warning (yellow) if the build errored
+# default (gray) by default
+# look for pass/fail/error in the title
+style=$(evaluate "$(jq -r '.params.style // "default"' < "${payload}")")
+[[ "${title}" =~ (pass|succeed|success) ]] && style="good"
+[[ "${title}" =~ (fail) ]] && style="attention"
+[[ "${title}" =~ (error) ]] && style="warning"
+# or in the text_output if we didn't find it in the title
+[[ "${style}" == "default" ]] && [[ "${text_output}" =~ (pass|succeed|success) ]] && style="good"
+[[ "${style}" == "default" ]] && [[ "${text_output}" =~ (fail) ]] && style="attention"
+[[ "${style}" == "default" ]] && [[ "${text_output}" =~ (error) ]] && style="warning"
+
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+
+body=$(jq -n --arg format "${format}" \
+  --arg actionName "${actionName}" \
+  --arg actionTarget "${actionTarget}" \
+  --arg title "${title}" \
+  --arg text "${text_output}" \
+  --arg style "${style}" \
+  -f ${DIR}/card.jq)
 
 webhook_url="$(jq -r '.source.url // empty' < "${payload}")"
 


### PR DESCRIPTION
related to #25 
- put the structure of the adaptive card into a `.jq` template file. you can use https://adaptivecards.io/designer/ to adjust the "content" section visually.
- the header of the card is visually distinct, if we can find a descriptive word in either the provided `title` or `text` content.
  - you can override this by passing a `style` param
- pulled the Dockerfile `apt-get`s into separate, earlier, `RUN` statement to take better advantage of `docker build` caching (for faster iterations).