### PR TITLE
key warning from title too

### DIFF
--- a/out
+++ b/out
@@ -56,7 +56,7 @@ fi
 style=$(evaluate "$(jq -r '.params.style // "default"' < "${payload}")")
 [[ "${title,,}" =~ (pass|succeed|success) ]] && style="good"
 [[ "${title,,}" =~ (fail) ]] && style="attention"
-[[ "${title,,}" =~ (error) ]] && style="warning"
+[[ "${title,,}" =~ (error|warning) ]] && style="warning"
 # or in the text_output if we didn't find it in the title
 [[ "${style}" == "default" ]] && [[ "${text_output,,}" =~ (pass|succeed|success) ]] && style="good"
 [[ "${style}" == "default" ]] && [[ "${text_output,,}" =~ (fail) ]] && style="attention"


### PR DESCRIPTION
in #50 I added the check for "warning" in the `text_output` and didn't realize I missed the same check within the `title`