### PR TITLE
Fix Concourse Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Concourse CI Teams Resource
 
 Sends messages to [Microsoft Teams](https://teams.microsoft.com) from
-within [Concourse CI](https://concourse.ci) pipelines.
+within [Concourse CI](https://concourse-ci.org/) pipelines.
 
 Implements the Microsoft Teams
 [Connector](https://dev.outlook.com/Connectors/Reference) protocols and
-the Concourse CI [resource](https://concourse.ci/implementing-resources.html)
+the Concourse CI [resource](https://concourse-ci.org/implementing-resource-types.html)
 protocols.
 
 ![teams](images/teams2.png)

--- a/out
+++ b/out
@@ -24,7 +24,7 @@ format="markdown"
 
 actionName=$(evaluate "$(jq -r '.params.actionName // "Open Concourse"' < "${payload}")")
 
-actionTarget=$(evaluate "$(jq -r '.params.actionTarget // "https://concourse.ci"' < "${payload}")")
+actionTarget=$(evaluate "$(jq -r '.params.actionTarget // "https://concourse-ci.org/"' < "${payload}")")
 
 title=$(evaluate "$(jq -r '.params.title // "Concourse CI"' < "${payload}")")
 


### PR DESCRIPTION
The old domain no longer has a valid certificate. The resource type documentation was moved as well.