### PR TITLE
Upgrade Base Image to Ubuntu 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y curl jq
+    DEBIAN_FRONTEND=noninteractive apt-get install -y curl jq && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY check   /opt/resource/check
 COPY in      /opt/resource/in


### PR DESCRIPTION
Ubuntu 24.04 is a slightly smaller starting image. Delete apt cache after installing packages to farther reduce image size.

Testing image size locally the current image came in at 143Mb. The new image is 91Mb.